### PR TITLE
Implement denylist for repos

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -109,6 +109,7 @@ const (
 	// RepoWhitelistFlag is deprecated for RepoAllowlistFlag.
 	RepoWhitelistFlag          = "repo-whitelist"
 	RepoAllowlistFlag          = "repo-allowlist"
+	RepoDenylistFlag           = "repo-denylist"
 	RequireApprovalFlag        = "require-approval"
 	RequireMergeableFlag       = "require-mergeable"
 	SilenceNoProjectsFlag      = "silence-no-projects"
@@ -349,6 +350,11 @@ var stringFlags = map[string]stringFlag{
 			"The format is {hostname}/{owner}/{repo}, ex. github.com/runatlantis/atlantis. '*' matches any characters until the next comma. Examples: " +
 			"all repos: '*' (not secure), an entire hostname: 'internalgithub.com/*' or an organization: 'github.com/runatlantis/*'." +
 			" For Bitbucket Server, {owner} is the name of the project (not the key).",
+	},
+	RepoDenylistFlag: {
+		description: "Comma separated list of repositories that Atlantis will skip. " +
+			"If a repo is matched by the allow list but also matched by the denylist, it will not be operated on. " +
+			"The format is the same as --repo-allowlist.",
 	},
 	RepoWhitelistFlag: {
 		description: "[Deprecated for --repo-allowlist].",
@@ -895,6 +901,9 @@ func (s *ServerCmd) validate(userConfig server.UserConfig) error {
 	}
 	if strings.Contains(userConfig.RepoAllowlist, "://") {
 		return fmt.Errorf("--%s cannot contain ://, should be hostnames only", RepoAllowlistFlag)
+	}
+	if strings.Contains(userConfig.RepoDenyList, "://") {
+		return fmt.Errorf("--%s cannot contain ://, should be hostnames only", RepoDenylistFlag)
 	}
 	if userConfig.SilenceAllowlistErrors && userConfig.SilenceWhitelistErrors {
 		return fmt.Errorf("both --%s and --%s cannot be set–use --%s", SilenceAllowlistErrorsFlag, SilenceWhitelistErrorsFlag, SilenceAllowlistErrorsFlag)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -95,6 +95,7 @@ var testFlags = map[string]interface{}{
 	PortFlag:                         8181,
 	ParallelPoolSize:                 100,
 	RepoAllowlistFlag:                "github.com/runatlantis/atlantis",
+	RepoDenylistFlag:                 "",
 	RequireApprovalFlag:              true,
 	RequireMergeableFlag:             true,
 	SilenceNoProjectsFlag:            false,
@@ -272,6 +273,18 @@ func TestExecute_RepoAllowlistScheme(t *testing.T) {
 	err := c.Execute()
 	Assert(t, err != nil, "should be an error")
 	Equals(t, "--repo-allowlist cannot contain ://, should be hostnames only", err.Error())
+}
+
+// Should error if the repo denylist contained a scheme.
+func TestExecute_RepoDenylistScheme(t *testing.T) {
+	c := setup(map[string]interface{}{
+		GHUserFlag:       "user",
+		GHTokenFlag:      "token",
+		RepoDenylistFlag: "http://github.com/*",
+	}, t)
+	err := c.Execute()
+	Assert(t, err != nil, "should be an error")
+	Equals(t, "--repo-denylist cannot contain ://, should be hostnames only", err.Error())
 }
 
 func TestExecute_ValidateLogLevel(t *testing.T) {

--- a/runatlantis.io/docs/security.md
+++ b/runatlantis.io/docs/security.md
@@ -48,6 +48,8 @@ For example:
 * Every repository in your GitHub Enterprise install: `--repo-allowlist=github.yourcompany.com/*`
 * All repositories: `--repo-allowlist=*`. Useful for when you're in a protected network but dangerous without also setting a webhook secret.
 
+You can also specify the `--repo-denylist` flag to exclude repos included by the allow list.
+
 This flag ensures your Atlantis install isn't being used with repositories you don't control. See `atlantis server --help` for more details.
 
 ### Protect Terraform Planning

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -802,6 +802,27 @@ This is useful when you have many projects and want to keep the pull request cle
   * Allowlist all repositories
     * `--repo-allowlist='*'`
 
+
+### `--repo-denylist`
+  ```bash
+  # NOTE: Use single quotes to avoid shell expansion of *.
+  atlantis server --repo-denylist='github.com/myorg/*'
+  # or
+  ATLANTIS_REPO_DENYLIST='github.com/myorg/*'
+  ```
+  Atlantis allows you to specify an denylist in addition to the required allowlist, which it will ignore webhooks from
+
+  Notes:
+  * Format is identical to `--repo-allowlist`, see above.
+  * While allowlist is required, denylist is optional
+  * If a repo matches both allowlist *and* denylist, it will be *denied*.
+
+  Examples:
+  * Allow all of `myorg/*` except `myorg/badrepo1` and `myorg/badrepo2` on `github.com`
+    * `--repo-allowlist='github.com/myorg/*' --repo-denylist='github.com/myorg/badrepo1,github.com/myorg/badrepo2'`
+  * Allow all servers except github
+    * `--repo-allowlist='*' --repo-denylist='github.com/*'`
+
 ### `--silence-fork-pr-errors`
   ```bash
   atlantis server --silence-fork-pr-errors

--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -27,7 +27,7 @@ type APIController struct {
 	ProjectCommandBuilder     events.ProjectCommandBuilder
 	ProjectPlanCommandRunner  events.ProjectPlanCommandRunner
 	ProjectApplyCommandRunner events.ProjectApplyCommandRunner
-	RepoAllowlistChecker      *events.RepoAllowlistChecker
+	RepoMatchChecker          *events.RepoMatchChecker
 	Scope                     tally.Scope
 	VCSClient                 vcs.Client
 }
@@ -208,8 +208,8 @@ func (a *APIController) apiParseAndValidate(r *http.Request) (*APIRequest, *comm
 	}
 
 	// Check if the repo is allowlisted
-	if !a.RepoAllowlistChecker.IsAllowlisted(baseRepo.FullName, baseRepo.VCSHost.Hostname) {
-		return nil, nil, http.StatusForbidden, fmt.Errorf("repo not allowlisted")
+	if !a.RepoMatchChecker.Matches(baseRepo.FullName, baseRepo.VCSHost.Hostname) {
+		return nil, nil, http.StatusForbidden, fmt.Errorf("repo does not match allow and deny list")
 	}
 
 	return &request, &command.Context{

--- a/server/controllers/api_controller_test.go
+++ b/server/controllers/api_controller_test.go
@@ -66,7 +66,7 @@ func setup(t *testing.T) (controllers.APIController, *MockProjectCommandBuilder,
 	scope, _, _ := metrics.NewLoggingScope(logger, "null")
 	parser := NewMockEventParsing()
 	vcsClient := NewMockClient()
-	repoAllowlistChecker, err := events.NewRepoAllowlistChecker("*")
+	repoMatchChecker, err := events.NewRepoMatchChecker("*", "")
 	Ok(t, err)
 
 	projectCommandBuilder := NewMockProjectCommandBuilder()
@@ -97,7 +97,7 @@ func setup(t *testing.T) (controllers.APIController, *MockProjectCommandBuilder,
 		ProjectPlanCommandRunner:  projectCommandRunner,
 		ProjectApplyCommandRunner: projectCommandRunner,
 		VCSClient:                 vcsClient,
-		RepoAllowlistChecker:      repoAllowlistChecker,
+		RepoMatchChecker:          repoMatchChecker,
 	}
 	return ac, projectCommandBuilder, projectCommandRunner
 }

--- a/server/controllers/events/events_controller_e2e_test.go
+++ b/server/controllers/events/events_controller_e2e_test.go
@@ -1385,7 +1385,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		PullStatusFetcher:              backend,
 	}
 
-	repoAllowlistChecker, err := events.NewRepoAllowlistChecker("*")
+	repoMatchChecker, err := events.NewRepoMatchChecker("*", "")
 	Ok(t, err)
 
 	ctrl := events_controllers.VCSEventsController{
@@ -1407,7 +1407,7 @@ func setupE2E(t *testing.T, repoDir string, opt setupOption) (events_controllers
 		GithubRequestValidator:       &events_controllers.DefaultGithubRequestValidator{},
 		GitlabRequestParserValidator: &events_controllers.DefaultGitlabRequestParserValidator{},
 		GitlabWebhookSecret:          nil,
-		RepoAllowlistChecker:         repoAllowlistChecker,
+		RepoMatchChecker:             repoMatchChecker,
 		SupportedVCSHosts:            []models.VCSHostType{models.Gitlab, models.Github, models.BitbucketCloud},
 		VCSClient:                    e2eVCSClient,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -798,7 +798,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		TeamAllowlistChecker:           githubTeamAllowlistChecker,
 		VarFileAllowlistChecker:        varFileAllowlistChecker,
 	}
-	repoAllowlist, err := events.NewRepoAllowlistChecker(userConfig.RepoAllowlist)
+	repoMatchChecker, err := events.NewRepoMatchChecker(userConfig.RepoAllowlist, userConfig.RepoDenyList)
 	if err != nil {
 		return nil, err
 	}
@@ -842,7 +842,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		ProjectCommandBuilder:     projectCommandBuilder,
 		ProjectPlanCommandRunner:  instrumentedProjectCmdRunner,
 		ProjectApplyCommandRunner: instrumentedProjectCmdRunner,
-		RepoAllowlistChecker:      repoAllowlist,
+		RepoMatchChecker:          repoMatchChecker,
 		Scope:                     statsScope.SubScope("api"),
 		VCSClient:                 vcsClient,
 	}
@@ -859,7 +859,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		GithubRequestValidator:          &events_controllers.DefaultGithubRequestValidator{},
 		GitlabRequestParserValidator:    &events_controllers.DefaultGitlabRequestParserValidator{},
 		GitlabWebhookSecret:             []byte(userConfig.GitlabWebhookSecret),
-		RepoAllowlistChecker:            repoAllowlist,
+		RepoMatchChecker:                repoMatchChecker,
 		SilenceAllowlistErrors:          userConfig.SilenceAllowlistErrors,
 		EmojiReaction:                   userConfig.EmojiReaction,
 		ExecutableName:                  userConfig.ExecutableName,

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -77,6 +77,7 @@ type UserConfig struct {
 	RepoConfig                      string `mapstructure:"repo-config"`
 	RepoConfigJSON                  string `mapstructure:"repo-config-json"`
 	RepoAllowlist                   string `mapstructure:"repo-allowlist"`
+	RepoDenyList                    string `mapstructure:"repo-denylist"`
 	// RepoWhitelist is deprecated in favour of RepoAllowlist.
 	RepoWhitelist string `mapstructure:"repo-whitelist"`
 


### PR DESCRIPTION
## what

Add an optional flag `--repo-denylist` which omits repos that are included by `--repo-allowlist`.

The the default value (`""`) is a no-op, since it doesn't "deny" anything, so this is backwards compatible.


## why

In general, useful to have denys if you have allows. As a specific example, in our setup, we have repos foo/* that we want to be tracked by atlantis, but sometimes we want to omit a repo to do some testing, so this will allow us to do `--repos-allowlist='foo/*' --repos-denylist=foo/bar`.

## tests

I searched the whole repo for "allow.?list" and updated each place it occurred. 

I added several unit tests to the previous code that matched the allow list. All the existing test use the default string (`""`), so I'm confident this is backwards compatible.

## references

Closes #1180